### PR TITLE
Update rt_linux.c

### DIFF
--- a/src/os/linux/rt_linux.c
+++ b/src/os/linux/rt_linux.c
@@ -1185,8 +1185,8 @@ static inline void __RtmpOSFSInfoChange(OS_FS_INFO * pOSFSInfo, BOOLEAN bSet)
 		pOSFSInfo->fsgid = current->fsgid;
 		current->fsuid = current->fsgid = 0;
 #else
-		pOSFSInfo->fsuid = current_fsuid();
-		pOSFSInfo->fsgid = current_fsgid();
+		pOSFSInfo->fsuid = *(int*)&current_fsuid();
+		pOSFSInfo->fsgid = *(int*)&current_fsgid();
 #endif
 		pOSFSInfo->fs = get_fs();
 		set_fs(KERNEL_DS);


### PR DESCRIPTION
I met an error when compiling rt_linux.c with gcc 4.9.1 on Debian jessie/sid i386. Then I found a solution in <a  href="http://blog.sina.com.cn/s/blog_4d31f1650101ejlt.html">this page</a>.I think this change will not influence compiling on platforms that don't have this problem.
I will find out why the return type of function current_fsuid/current_fsgid is different on different platforms later.
